### PR TITLE
feat(ls): implement parallel directory traversal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rkit"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "Rust CLI Toolkit for Git Repo Management"
 authors = ["Justin Thomas <admin@imthor.in>"]


### PR DESCRIPTION
- Add parallel directory scanning using ignore crate's parallel walker
- Replace sequential counters with thread-safe AtomicUsize and Mutex
- Configure thread count based on user settings
- Bump version to 0.1.10