### PR TITLE
Skip descending into detected repositories

### DIFF
--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -134,6 +134,15 @@ pub fn list_repos(
                                 return WalkState::Quit;
                             }
                         }
+
+                        if config.stop_at_git
+                            && entry
+                                .file_type()
+                                .map(|ft| ft.is_dir())
+                                .unwrap_or(false)
+                        {
+                            return WalkState::Skip;
+                        }
                     }
                 }
                 Err(e) => log::error!("Error walking directory: {}", e),


### PR DESCRIPTION
This change adds a check in the directory walker to skip traversing directories when the stop_at_git config flag is set. This prevents unnecessary recursion into directories that should be ignored, improving performance and clarity in the repository listing process.